### PR TITLE
removing encoding parameter in pickle.load call

### DIFF
--- a/app/model/alpha_cnn_predict.py
+++ b/app/model/alpha_cnn_predict.py
@@ -4,7 +4,7 @@ from app.model.preprocessor import Preprocessor as img_prep
 
 class LiteOCR:
 	def __init__(self, fn="alpha_weights.pkl", pool_size=2):
-		[weights, meta] = pickle.load(open(fn, 'rb'), encoding='latin1') #currently, this class MUST be initialized from a pickle file
+		[weights, meta] = pickle.load(open(fn, 'rb')) #currently, this class MUST be initialized from a pickle file
 		self.vocab = meta["vocab"]
 
 		self.img_rows = meta["img_side"] ; self.img_cols = meta["img_side"]


### PR DESCRIPTION
Hi Siraj,

I'm learning about deep neural networks so i forked your repo to do some tests.
however when i run the web app i got a:
```
 ImportError: bad magic number in 'config': b'\x03\xf3\r\n'
```
So i found out that this was caused by the encoding parameter in the pickle load call.
I just removed the parameter and it worked.
I'm sending this pull request in case this can be helpful for other people that may have this issue too.

here the complete stack trace of the error:
```
$ python3 run.py
Traceback (most recent call last):
  File "/home/rhuanca/.local/lib/python3.6/site-packages/werkzeug/utils.py", line 412, in import_string
    __import__(import_name)
ImportError: bad magic number in 'config': b'\x03\xf3\r\n'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "run.py", line 2, in <module>
    from app import app
  File "/home/rhuanca/src-stats/Convolutional_neural_network/app/__init__.py", line 6, in <module>
    app.config.from_object('config')
  File "/home/rhuanca/.local/lib/python3.6/site-packages/flask/config.py", line 162, in from_object
    obj = import_string(obj)
  File "/home/rhuanca/.local/lib/python3.6/site-packages/werkzeug/utils.py", line 437, in import_string
    sys.exc_info()[2])
  File "/home/rhuanca/.local/lib/python3.6/site-packages/werkzeug/_compat.py", line 133, in reraise
    raise value.with_traceback(tb)
  File "/home/rhuanca/.local/lib/python3.6/site-packages/werkzeug/utils.py", line 412, in import_string
    __import__(import_name)
werkzeug.utils.ImportStringError: import_string() failed for 'config'. Possible reasons are:

- missing __init__.py in a package;
- package or module path not included in sys.path;
- duplicated package or module name taking precedence in sys.path;
- missing module, class, function or variable;

Debugged import:

- 'config' not found.

Original exception:

ImportError: bad magic number in 'config': b'\x03\xf3\r\n'
```
